### PR TITLE
Adjust word size

### DIFF
--- a/Blabber.rb
+++ b/Blabber.rb
@@ -29,6 +29,7 @@ class Blabber < Sinatra::Base
     QUERY_TEXT = "http://api.nytimes.com/svc/search/v2/articlesearch.json?"
     @@latest_query = DateTime.new(0)
     @@cached_results = ""
+    @@number_of_daily_queries = 0
   end
 
   
@@ -40,12 +41,19 @@ class Blabber < Sinatra::Base
   get '/daily-data' do
     today = DateTime.now
     if today.strftime("%Y%m%d") != @@latest_query.strftime("%Y%m%d")  # this is new day put @@latest_query in history array
-      
-    #if today.strftime("%H") != @@latest_query.strftime("%H")     # in this case it is the same day just update at the hour  
+      puts "Hittin first time today"
+      @@number_of_daily_queries = 1
       @@latest_query = DateTime.now
-		  @@cached_results = daily_api_call((@@latest_query - 1).strftime("%Y%m%d"),
+      @@cached_results = daily_api_call((@@latest_query - 1).strftime("%Y%m%d"),
       @@latest_query.strftime("%Y%m%d"))
-                                      
+    else
+      if today.strftime("%H") != @@latest_query.strftime("%H")     # in this case it is the same day just update at the hour  
+        puts "Update on the hour"
+        @@number_of_daily_queries += 1  
+        @@latest_query = DateTime.now
+		    @@cached_results = daily_api_call((@@latest_query - 1).strftime("%Y%m%d"),
+        @@latest_query.strftime("%Y%m%d"))
+      end                                
     end
 
 		@@cached_results.to_json

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ https://github.com/jasondavies/d3-cloud
 In order to use JS libraries and frameworks like angular, D3, etc. some of your routes have to return JSON which will be used by JS framework in another route (that happens via AJAX) - take a look at views/home.slim for such an example.
 
 ## Sinatra quirks
-Modules that are in separate files should be in lib/sinatra directory and be in module Sinatra. see helpers.rb
+Modules that are in separate files should be in lib/sinatra directory and be in module Sinatra. See helpers.rb.
 
 ## To run the application 
 `bundle exec rackup -p 3000`

--- a/lib/sinatra/helpers.rb
+++ b/lib/sinatra/helpers.rb
@@ -9,8 +9,7 @@ module Sinatra
       
         word_frequencies = Hash.new(0)
         counter = 0
-        # for normalizing words size in the cloud
-        min_frequency = 1           # can I get away with this assumption
+       
         max_frequency = 0
       
       

--- a/lib/sinatra/helpers.rb
+++ b/lib/sinatra/helpers.rb
@@ -1,5 +1,8 @@
 
 module Sinatra
+
+  MAX_WORD_SIZE = 80
+
   module Helpers
 
 	  def daily_api_call(date_first, date_second)
@@ -39,8 +42,9 @@ module Sinatra
             end 
           end  
         end
-        #word_frequencies["total_number_of_words"] = counter
-        puts "Max frequency: #{max_frequency}"
+        word_frequencies.delete_if { |key, value| value < 2 }
+        word_frequencies["word_scale"] = MAX_WORD_SIZE / max_frequency
+        puts word_frequencies.length
         word_frequencies
     end
   end

--- a/views/home.slim
+++ b/views/home.slim
@@ -1,6 +1,5 @@
 header
 
-
 div id='content'
 
 <!-- This script taken from example in https://github.com/jasondavies/d3-cloud -->
@@ -12,16 +11,21 @@ javascript:
      function getData(collection){
 
        $("#content").empty().html('<img src="./images/ajax-loader.gif" />');
-
+       var word_scale;
        $.getJSON("/daily-data", function(data) {
          $.each(data, function(key, value){
+           if(key == 'word_scale'){
+             word_scale = value;
+           } else {
            collection.push({'frequency': value,
                             'word': key});
+           }
          });
-         
+           
          d3.layout.cloud().size([600, 600])
              .words(collection.map(function(d) {
-                return {text: d['word'], size: 5 + d['frequency'] * 4};
+                return { text: d['word'], 
+                         size: Math.ceil(word_scale * d['frequency']) };
            }))
            .padding(2)
            .rotate(function() { return ~~(Math.random() * 2) * 90; })
@@ -37,22 +41,22 @@ javascript:
      getData(words_in_text);
 
      function draw(words) {
-      d3.select("#content").append("svg")
-        .attr("width", 600)
-        .attr("height", 600)
-      .append("g")
-        .attr("transform", "translate(300,300)")
-      .selectAll("text")
-        .data(words)
-      .enter().append("text")
-        .style("font-size", function(d) { return d.size + "px"; })
-        .style("font-family", "Impact")
-        .style("fill", function(d, i) { return fill(i); })
-        .attr("text-anchor", "middle")
-        .attr("transform", function(d) {
-          return "translate(" + [d.x, d.y] + ")rotate(" + d.rotate + ")";
-        })
-        .text(function(d) { return d.text; });
-        $("img").toggle();
+       d3.select("#content").append("svg")
+         .attr("width", 600)
+         .attr("height", 600)
+       .append("g")
+         .attr("transform", "translate(300,300)")
+       .selectAll("text")
+         .data(words)
+       .enter().append("text")
+         .style("font-size", function(d) { return d.size + "px"; })
+         .style("font-family", "Impact")
+         .style("fill", function(d, i) { return fill(i); })
+         .attr("text-anchor", "middle")
+         .attr("transform", function(d) {
+           return "translate(" + [d.x, d.y] + ")rotate(" + d.rotate + ")";
+         })
+         .text(function(d) { return d.text; });
+         $("img").toggle();
     }
      


### PR DESCRIPTION
Introduced arbitrary maximum size of word that is most frequent, all other words are scaled according to their frequency.
Removed words that appear only once in the call. Hash size reduced by 60% (consider how would that affect calls throughout the day; should I keep one larger hash on the server and send to client slimmed down version). Good thing is that script is faster on the client with less words to render.
